### PR TITLE
Fix(ui): Set window icon to prevent placeholder on Linux

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -160,6 +160,11 @@ class MainWindow(QMainWindow):
         self.setWindowTitle(config.APP_NAME)
         self.setGeometry(100, 100, 1200, 800)
 
+        # Set window icon
+        icon = QIcon.fromTheme("com.rectifex.GlobalReboundScreener")
+        if not icon.isNull():
+            self.setWindowIcon(icon)
+
         self.chart_windows = []
         self.results_df = pd.DataFrame()
 


### PR DESCRIPTION
When the application is running on a Linux desktop environment like KDE, the icon in the task manager or dock would revert to a placeholder when the application was active or hovered over. This was because the application window itself did not have an icon set, causing the window manager to fail to associate it correctly with the application's `.desktop` file.

This change fixes the issue by explicitly setting the window icon in the `MainWindow` using `QIcon.fromTheme()`. This ensures the running application window carries the correct icon, allowing the desktop environment to display it consistently.