### PR TITLE
fix: Resolve KeyError on tooltip generation

### DIFF
--- a/rebound_scenarios.py
+++ b/rebound_scenarios.py
@@ -136,10 +136,13 @@ class ScenarioRunner:
 
         return is_candidate_A or is_candidate_B, rsi, dist_to_sma, dist_to_low
 
-    def _calculate_classic_score(self, rsi: float, dist_to_sma: float, dist_to_low: float) -> int:
-        """Calculates the score for the 'Classic Oversold' scenario."""
+    def _calculate_classic_score(self, rsi: float, dist_to_sma: float, dist_to_low: float) -> tuple[int, int, int]:
+        """
+        Calculates the rebound score and its components.
+        Returns the final score, the RSI sub-score, and the proximity sub-score.
+        """
         rsi_score = max(0, (config.RSI_SCORE_CEILING - rsi) * (100 / (config.RSI_SCORE_CEILING - config.RSI_OVERSOLD_STRONG)))
-        rsi_score = min(100, rsi_score)
+        rsi_score = int(min(100, rsi_score))
 
         prox_dist = np.inf
         if dist_to_sma >= 0: prox_dist = min(prox_dist, dist_to_sma)
@@ -149,9 +152,10 @@ class ScenarioRunner:
             proximity_score = 0
         else:
             proximity_score = (config.PROXIMITY_SCORE_CEILING - prox_dist) * (100 / config.PROXIMITY_SCORE_CEILING)
-        proximity_score = max(0, min(100, proximity_score))
+        proximity_score = int(max(0, min(100, proximity_score)))
 
-        return int((0.6 * rsi_score) + (0.4 * proximity_score))
+        final_score = int((0.6 * rsi_score) + (0.4 * proximity_score))
+        return final_score, rsi_score, proximity_score
 
     def run_classic_oversold(self) -> List[ReboundCandidate]:
         """
@@ -203,7 +207,7 @@ class ScenarioRunner:
                     continue
 
                 self._emit_progress(f"!!! {ticker} is a potential 'Classic Oversold' candidate!")
-                score = self._calculate_classic_score(rsi, dist_sma, dist_low)
+                score, rsi_score, prox_score = self._calculate_classic_score(rsi, dist_sma, dist_low)
 
                 candidate = ReboundCandidate(
                     ticker=ticker,
@@ -213,7 +217,9 @@ class ScenarioRunner:
                         'price': round(stock_data['Close'].iloc[-1], 2),
                         'rsi': round(rsi, 2),
                         'dist_sma_200': round(dist_sma, 2),
-                        'dist_low_90d': round(dist_low, 2)
+                        'dist_low_90d': round(dist_low, 2),
+                        'rsi_score': rsi_score,
+                        'prox_score': prox_score
                     },
                     fundamentals={'name': stock_info.get('shortName', 'N/A')}
                 )

--- a/ui.py
+++ b/ui.py
@@ -109,9 +109,13 @@ class PandasModel(QAbstractTableModel):
                     return QColor("#fff3cd")
 
             if role == Qt.ItemDataRole.ToolTipRole and column_name == "Score":
-                rsi_score = self._data.iloc[index.row()]["RSI_Score"]
-                prox_score = self._data.iloc[index.row()]["Prox_Score"]
-                return f"Score Breakdown:\n- RSI Score: {rsi_score} / 60\n- Proximity Score: {prox_score} / 40"
+                # Check if the score breakdown columns exist for this row
+                if 'RSI_Score' in self._data.columns and 'Prox_Score' in self._data.columns:
+                    rsi_score = self._data.iloc[index.row()]["RSI_Score"]
+                    prox_score = self._data.iloc[index.row()]["Prox_Score"]
+                    # Also check if they are not NaN or some other placeholder
+                    if pd.notna(rsi_score) and pd.notna(prox_score):
+                        return f"Score Breakdown:\n- RSI Score: {rsi_score} / 60\n- Proximity Score: {prox_score} / 40"
         return None
 
     def headerData(self, section, orientation, role=Qt.ItemDataRole.DisplayRole):
@@ -370,6 +374,9 @@ class MainWindow(QMainWindow):
                 "Price": r.technicals.get('price', 'N/A'),
                 "EPS-Wachstum": f"{r.fundamentals.get('earningsGrowth', 0) * 100:.2f}%" if r.fundamentals.get('earningsGrowth') is not None else "N/A",
                 "Umsatzwachstum": f"{r.fundamentals.get('revenueGrowth', 0) * 100:.2f}%" if r.fundamentals.get('revenueGrowth') is not None else "N/A",
+                # Add sub-scores for tooltip, using .get() to avoid KeyErrors for scenarios that don't have them
+                "RSI_Score": r.technicals.get('rsi_score'),
+                "Prox_Score": r.technicals.get('prox_score'),
             }
             results_list_of_dicts.append(res_dict)
 


### PR DESCRIPTION
This commit fixes a `KeyError: 'RSI_Score'` that occurred when the UI tried to render the score breakdown tooltip for the results table.

The error was caused by two issues during the refactoring:
1. The backend `_calculate_classic_score` function was no longer returning the sub-scores (`rsi_score`, `prox_score`).
2. The frontend `display_results` method was not adding these sub-scores to the DataFrame used by the table model.

This commit addresses both issues:
- The `_calculate_classic_score` method in `rebound_scenarios.py` now returns the sub-scores.
- The `run_classic_oversold` method now stores these sub-scores in the `ReboundCandidate.technicals` dictionary.
- The `display_results` method in `ui.py` now extracts the sub-scores from the candidate object and adds them to the DataFrame, using `.get()` to handle scenarios where they might not be present.
- The tooltip generation logic in `PandasModel` is now more robust and checks for the existence of the sub-score columns before trying to access them.