### PR TITLE
fix: Improve fundamental filter and UI display

### DIFF
--- a/rebound_scenarios.py
+++ b/rebound_scenarios.py
@@ -299,10 +299,21 @@ class ScenarioRunner:
             fundamentally_strong_tickers = {}
             for ticker, data in fundamental_data.items():
                 if data:
-                    eps_growth = data.get('earningsGrowth', 0) or 0
-                    revenue_growth = data.get('revenueGrowth', 0) or 0
-                    debt_to_equity = data.get('debtToEquity', float('inf')) or float('inf')
-                    if eps_growth > 0.10 and revenue_growth > 0.05 and debt_to_equity < 0.7:
+                    fundamental_score = 0
+
+                    eps_growth = data.get('earningsGrowth')
+                    if eps_growth is not None and eps_growth > 0.10:
+                        fundamental_score += 1
+
+                    revenue_growth = data.get('revenueGrowth')
+                    if revenue_growth is not None and revenue_growth > 0.05:
+                        fundamental_score += 1
+
+                    debt_to_equity = data.get('debtToEquity')
+                    if debt_to_equity is not None and debt_to_equity < 0.7:
+                        fundamental_score += 1
+
+                    if fundamental_score >= 2:
                         fundamentally_strong_tickers[ticker] = data
 
             if not fundamentally_strong_tickers:

--- a/ui.py
+++ b/ui.py
@@ -367,13 +367,16 @@ class MainWindow(QMainWindow):
         # Convert list of ReboundCandidate objects to a list of dicts for the DataFrame
         results_list_of_dicts = []
         for r in results:
+            eps_growth = r.fundamentals.get('earningsGrowth')
+            rev_growth = r.fundamentals.get('revenueGrowth')
+
             res_dict = {
                 "Ticker": r.ticker,
                 "Szenario": r.scenario,
                 "Score": r.score,
-                "Price": r.technicals.get('price', 'N/A'),
-                "EPS-Wachstum": f"{r.fundamentals.get('earningsGrowth', 0) * 100:.2f}%" if r.fundamentals.get('earningsGrowth') is not None else "N/A",
-                "Umsatzwachstum": f"{r.fundamentals.get('revenueGrowth', 0) * 100:.2f}%" if r.fundamentals.get('revenueGrowth') is not None else "N/A",
+                "Price": r.technicals.get('price', '-'),
+                "EPS-Wachstum": f"{eps_growth * 100:.2f}%" if eps_growth is not None else "-",
+                "Umsatzwachstum": f"{rev_growth * 100:.2f}%" if rev_growth is not None else "-",
                 # Add sub-scores for tooltip, using .get() to avoid KeyErrors for scenarios that don't have them
                 "RSI_Score": r.technicals.get('rsi_score'),
                 "Prox_Score": r.technicals.get('prox_score'),


### PR DESCRIPTION
This commit addresses user feedback on the "Quality Stock Pullback" scenario and the UI display.

1.  **Flexible Fundamental Filtering**: The fundamental filter for the "Quality Stock Pullback" scenario was too strict, often resulting in no candidates found. The logic has been changed from requiring all 3 criteria to be met to a more resilient scoring system where a stock is considered fundamentally strong if it meets at least 2 out of the 3 criteria. This makes the filter more practical and robust against missing data points from the source.

2.  **Clearer UI for N/A Data**: When running scenarios that do not use fundamental data (like "Classic Oversold"), the corresponding columns in the results table would display "N/A". This has been changed to a more neutral dash ("-") to make it clearer that the data is not applicable for that scenario, rather than missing.