### PR TITLE
Fix asyncio KeyError in FundamentalFetcher

### DIFF
--- a/fundamental_fetcher.py
+++ b/fundamental_fetcher.py
@@ -95,14 +95,17 @@ class FundamentalFetcher:
         if not tickers_to_fetch:
             return results
 
-        # Create async tasks for tickers that need fetching
-        tasks = {asyncio.create_task(self._fetch_single_ticker_data(t)): t for t in tickers_to_fetch}
+        # Create a list of named tasks for tickers that need fetching
+        tasks = [
+            asyncio.create_task(self._fetch_single_ticker_data(t), name=t)
+            for t in tickers_to_fetch
+        ]
 
         fetched_count = 0
         total_to_fetch = len(tickers_to_fetch)
 
         for task in asyncio.as_completed(tasks):
-            ticker = tasks[task]
+            ticker = task.get_name()
             try:
                 data = await task
                 if data:


### PR DESCRIPTION
The `get_fundamentals_for_tickers` method was experiencing a `KeyError` because it was using `asyncio.Task` objects as dictionary keys. The task object returned by `asyncio.as_completed` was not always found in the dictionary.

This commit refactors the task management to use named tasks instead. Each task is now created with a `name` corresponding to the stock ticker. The ticker is then retrieved from the completed task using `task.get_name()`. This is a more robust and idiomatic way to handle task-related metadata in asyncio.