### PR TITLE
fix: Resolve NameError crash on 'Stop Scan'

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -2,6 +2,7 @@
 # Contains all PyQt6 classes for the user interface.
 
 import sys
+import logging
 import pandas as pd
 import shutil
 from PyQt6.QtWidgets import (


### PR DESCRIPTION
This commit fixes a critical bug where the application would crash with a `NameError: name 'logging' is not defined` when the user clicked the 'Stop Scan' button.

The error was caused by a missing `import logging` statement in `ui.py`. This commit adds the required import, ensuring the `cancel()` method in the `AnalysisWorker` can execute correctly without crashing.

This change allows the 'Stop Scan' feature to work as intended, gracefully terminating the scan and returning the UI to its idle state without closing the application.