### PR TITLE
fix: Resolve mplfinance ValueError in chart window

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -161,7 +161,11 @@ class ChartWindow(QWidget):
                 QMessageBox.warning(self, "Data Error", f"Could not load historical data for {candidate.ticker}.")
                 return
 
-            data = data.last(f'{config.CHART_HISTORY_MONTHS}M')
+            # Address FutureWarning for .last()
+            end_date = data.index[-1]
+            start_date = end_date - pd.DateOffset(months=config.CHART_HISTORY_MONTHS)
+            data = data.loc[start_date:end_date]
+
             # Calculate all required indicators
             data['SMA50'] = calculate_sma(data['Close'], 50)
             data['SMA200'] = calculate_sma(data['Close'], config.SMA_SUPPORT_PERIOD)
@@ -170,37 +174,46 @@ class ChartWindow(QWidget):
             # --- Plotting ---
             fig = self.canvas.figure
             fig.clf()
-            # Create axes
-            gs = fig.add_gridspec(3, 1)
-            self.ax = fig.add_subplot(gs[0:2, 0]) # Main plot
-            ax2 = fig.add_subplot(gs[2, 0], sharex=self.ax) # RSI plot
+
+            # Create axes for candlestick, volume, and RSI
+            gs = fig.add_gridspec(3, 1, height_ratios=[2, 1, 1])
+            self.ax = fig.add_subplot(gs[0, 0]) # Main plot for price
+            ax_vol = fig.add_subplot(gs[1, 0], sharex=self.ax) # Volume plot
+            ax_rsi = fig.add_subplot(gs[2, 0], sharex=self.ax) # RSI plot
+
+            # Remove x-axis labels from the main and volume plots for a cleaner look
+            self.ax.tick_params(axis='x', which='both', bottom=False, top=False, labelbottom=False)
+            ax_vol.tick_params(axis='x', which='both', bottom=False, top=False, labelbottom=False)
 
             self.ax.set_ylabel('Price')
-            ax2.set_ylabel('RSI')
+            ax_vol.set_ylabel('Volume')
+            ax_rsi.set_ylabel('RSI')
 
             # --- Dynamic Overlays ---
             add_plots = []
             if candidate.scenario == "Quality Stock Pullback":
                 support_level = candidate.technicals.get('50_sma_value')
                 if support_level:
+                    # Plotting directly on the axis is fine for simple lines
                     self.ax.axhline(y=support_level, color='green', linestyle='--', label='50-Day SMA Support')
                 if not data['SMA50'].empty:
-                    add_plots.append(mpf.make_addplot(data['SMA50'], color='green', width=0.7))
+                    # For more complex plots that need to align with the candlestick data, use make_addplot
+                    add_plots.append(mpf.make_addplot(data['SMA50'], ax=self.ax, color='green', width=0.7))
 
             # Always plot 200 SMA for context
             if not data['SMA200'].empty:
-                add_plots.append(mpf.make_addplot(data['SMA200'], color='blue', width=0.7))
+                add_plots.append(mpf.make_addplot(data['SMA200'], ax=self.ax, color='blue', width=0.7))
 
             # Main candle plot
-            mpf.plot(data, type='candle', ax=self.ax, volume=self.ax.twinx(), addplot=add_plots, style='yahoo',
+            mpf.plot(data, type='candle', ax=self.ax, volume=ax_vol, addplot=add_plots, style='yahoo',
                     title=f'{candidate.ticker} - {candidate.scenario}')
 
             # RSI Plot
-            ax2.plot(data.index, data['RSI'], color='orange')
-            ax2.axhline(70, color='red', linestyle='--', linewidth=0.5)
-            ax2.axhline(30, color='green', linestyle='--', linewidth=0.5)
-            ax2.set_ylim(0, 100)
-            ax2.grid(True)
+            ax_rsi.plot(data.index, data['RSI'], color='orange')
+            ax_rsi.axhline(70, color='red', linestyle='--', linewidth=0.5)
+            ax_rsi.axhline(30, color='green', linestyle='--', linewidth=0.5)
+            ax_rsi.set_ylim(0, 100)
+            ax_rsi.grid(True)
 
             # --- Information Box ---
             eps_growth = candidate.fundamentals.get('earningsGrowth')

--- a/verify_plot_fix.py
+++ b/verify_plot_fix.py
@@ -1,0 +1,52 @@
+import sys
+import logging
+from unittest.mock import patch
+
+# We need a QApplication instance to create widgets, but we can't show them.
+from PyQt6.QtWidgets import QApplication
+app = QApplication.instance() or QApplication(sys.argv)
+
+# Now we can import our application code
+from ui import ChartWindow
+from data_structures import ReboundCandidate
+import data_loader
+
+logging.basicConfig(level=logging.INFO)
+
+def run_verification():
+    """
+    Tests that the new ChartWindow plotting logic does not raise a ValueError.
+    """
+    print("--- Starting plot fix verification ---")
+
+    # 1. Use a real ticker to get realistic data
+    ticker = 'MSFT'
+    candidate = ReboundCandidate(
+        ticker=ticker,
+        scenario="Quality Stock Pullback",
+        score=80,
+        tooltip_text="A valid candidate for testing",
+        technicals=data_loader.get_stock_data(ticker).iloc[-1].to_dict(),
+        fundamentals={'name': 'Microsoft Corp', 'earningsGrowth': 0.2, 'revenueGrowth': 0.15}
+    )
+
+    # 2. Patch QWidget.show to prevent the chart window from trying to render.
+    with patch('PyQt6.QtWidgets.QWidget.show') as mock_show:
+
+        print(f"\nInstantiating ChartWindow with a valid candidate ({ticker})...")
+        try:
+            # 3. Instantiate the ChartWindow. This should trigger the plotting logic.
+            chart_window = ChartWindow(candidate=candidate)
+            print("ChartWindow instantiated successfully.")
+
+            print("\n--- VERIFICATION PASSED ---")
+            print("The ChartWindow constructor and plotting logic completed without raising an exception.")
+
+        except Exception as e:
+            # This block should NOT be reached.
+            print(f"\n--- !!! VERIFICATION FAILED !!! ---")
+            logging.error("An unhandled exception escaped the ChartWindow constructor.", exc_info=True)
+            return
+
+if __name__ == "__main__":
+    run_verification()


### PR DESCRIPTION
This commit addresses a `ValueError` that occurred during chart plotting, which was revealed after a previous fix prevented the application from crashing entirely.

The error `ValueError: make_addplot() ax kwargs must all be of type matplotlib.axis.Axes` was caused by an internal conflict within `mplfinance` when using `addplot` overlays in conjunction with an implicitly created volume axis (`volume=self.ax.twinx()`).

The fix involves refactoring the plotting logic in `ui.py`:
1.  The price, volume, and RSI axes are now created explicitly using `fig.add_subplot()` with a `gridspec`.
2.  The explicitly created volume axis is passed to `mpf.plot(volume=ax_vol)`, which resolves the conflict.
3.  The `ax` parameter is now correctly passed to all `mpf.make_addplot()` calls to ensure overlays are drawn on the correct (price) axis.

Additionally, this commit resolves a `FutureWarning` from pandas by replacing the deprecated `data.last()` method with the modern `.loc` and `pd.DateOffset` approach.