### PR TITLE
fix: Resolve `suptitle` AttributeError in chart window

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -204,9 +204,10 @@ class ChartWindow(QWidget):
             if not data['SMA200'].empty:
                 add_plots.append(mpf.make_addplot(data['SMA200'], ax=self.ax, color='blue', width=0.7))
 
+            self.ax.set_title(f'{candidate.ticker} - {candidate.scenario}')
+
             # Main candle plot
-            mpf.plot(data, type='candle', ax=self.ax, volume=ax_vol, addplot=add_plots, style='yahoo',
-                    title=f'{candidate.ticker} - {candidate.scenario}')
+            mpf.plot(data, type='candle', ax=self.ax, volume=ax_vol, addplot=add_plots, style='yahoo')
 
             # RSI Plot
             ax_rsi.plot(data.index, data['RSI'], color='orange')


### PR DESCRIPTION
This commit fixes a follow-up bug in the chart plotting logic where an `AttributeError: 'NoneType' object has no attribute 'suptitle'` would be raised by `mplfinance`.

This error occurred because of a subtle issue in how `mplfinance` handles the figure object when a title is passed as an argument while also using externally created axes.

The fix is to avoid the problematic code path in `mplfinance` entirely:
- The `title` keyword argument is removed from the `mpf.plot()` call.
- The chart title is now set directly on the main axis object via `self.ax.set_title()`.

This achieves the same visual result while being more robust and avoiding the internal library error.