### PR TITLE
fix: Correct sha256 checksum for ta-lib source

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -25,7 +25,7 @@
                 {
                     "type": "archive",
                     "url": "http://prdownloads.sourceforge.net/ta-lib/ta-lib-0.4.0-src.tar.gz",
-                    "sha256": "e3c11e5b53053d8a293acf25514032a49de58d799e43b593d6a69da781a07353"
+                    "sha256": "9ff41efcb1c011a4b4b6dfc91610b06e39b1d7973ed5d4dee55029a0ac4dc651"
                 }
             ]
         },


### PR DESCRIPTION
The flatpak build was failing because the sha256 checksum for the downloaded `ta-lib-0.4.0-src.tar.gz` did not match the one specified in `flathub.json`.

This commit updates the `sha256` value in `flathub.json` to the correct hash provided by the build logs, which will allow the dependency to be verified and built correctly.