### PR TITLE
Fix chart data being squished to the left

### DIFF
--- a/config.py
+++ b/config.py
@@ -82,6 +82,7 @@ PROXIMITY_SCORE_CEILING = 3.0 # Distance in percent that corresponds to a score 
 
 # -- GUI Configuration --
 APP_NAME = "Rectifex RB - Global Rebound Stock Screener"
+# The number of months of historical data to display on the chart.
 CHART_HISTORY_MONTHS = 12
 CSV_EXPORT_FILENAME = "rebound_candidates.csv"
 XLSX_EXPORT_FILENAME = "rebound_candidates.xlsx"

--- a/ui.py
+++ b/ui.py
@@ -252,7 +252,14 @@ class ChartWindow(QWidget):
                 self.canvas.draw()
                 return
 
-            plot_data = candidate.history_df.copy()
+            history_df = candidate.history_df.copy()
+
+            # Limit data to the configured number of months for charting
+            if not history_df.empty and config.CHART_HISTORY_MONTHS > 0:
+                cutoff_date = history_df.index.max() - pd.DateOffset(months=config.CHART_HISTORY_MONTHS)
+                plot_data = history_df.loc[cutoff_date:]
+            else:
+                plot_data = history_df
 
             # --- Indicator Calculations ---
             if 'SMA50' not in plot_data.columns:


### PR DESCRIPTION
The stock chart was displaying all available historical data (18 months), which caused a visual bug where the plot appeared squished on the left side of the chart area.

This change introduces logic to limit the amount of data sent to the plotting function. It now respects the `CHART_HISTORY_MONTHS` setting in `config.py` to display a more reasonable and readable time window (e.g., 12 months).

A comment was also added to `config.py` to clarify the purpose of the `CHART_HISTORY_MONTHS` setting.