### PR TITLE
feat: Add "Fundamental Divergence" scenario

### DIFF
--- a/rebound_scenarios.py
+++ b/rebound_scenarios.py
@@ -990,10 +990,17 @@ class FundamentalDivergenceScenario(BaseScenario):
             if not fund_data: continue
 
             # --- (A) Initial Fundamental Filter ---
+            d2e = fund_data.get('debtToEquity')
+            # Handle potential data anomaly where D/E is given as a percentage.
+            if d2e is not None and d2e > 10:
+                self._emit_progress(f"Correcting anomalous D/E ratio for {ticker} from {d2e} to {d2e/100}")
+                d2e = d2e / 100.0
+                fund_data['debtToEquity'] = d2e # Update dict for scoring
+
             if not (fund_data.get('revenueGrowth') is not None and fund_data.get('revenueGrowth', 0) >= config.FD_MIN_REVENUE_GROWTH and
                     fund_data.get('earningsGrowth') is not None and fund_data.get('earningsGrowth', -1) >= 0 and
                     fund_data.get('freeCashflow') is not None and fund_data.get('freeCashflow', -1) > 0 and
-                    fund_data.get('debtToEquity') is not None and 0 < fund_data.get('debtToEquity', 999) < config.FD_MAX_DEBT_TO_EQUITY):
+                    d2e is not None and 0 < d2e < config.FD_MAX_DEBT_TO_EQUITY):
                 continue
 
             stock_data = data_loader.get_stock_data(ticker)


### PR DESCRIPTION
- Adds a new screening scenario to identify fundamentally strong stocks that are currently underperforming or consolidating.
- The scenario is based on a detailed specification including fundamental criteria (revenue growth, FCF, debt-to-equity) and technical criteria (price range, SMA proximity, relative performance).
- Implements a weighted scoring system (0-100) to rank candidates.
- Updates the data fetcher to retrieve necessary financial data points (`freeCashflow`, `forwardPE`, `enterpriseToEbitda`).
- Integrates the new scenario into the UI, including adding it to the scenario list, providing a detailed score breakdown in a tooltip, and adding a description to the "About" dialog.

fix: Handle anomalous Debt-to-Equity data

- The Debt-to-Equity filter was correctly excluding stocks like ADBE due to anomalously high D/E ratios from the data provider.
- The logic is now updated to detect D/E ratios > 10, assume they are percentages, and divide by 100 before filtering.
- This preserves the integrity of the `< 1.0` filter for valid data while correctly handling data anomalies, ensuring stocks like Adobe are included as intended by the user.