### PR TITLE
Fix Flatpak build by unsetting LD_PRELOAD

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -9,7 +9,8 @@
         "--filesystem=home",
         "--socket=x11",
         "--socket=wayland",
-        "--device=dri"
+        "--device=dri",
+        "--unset-env=LD_PRELOAD"
     ],
     "modules": [
         {


### PR DESCRIPTION
The Flatpak build was failing with an error related to `LD_PRELOAD` and `libtcmalloc.so`. This is likely due to a change in the KDE Flatpak SDK/runtime.

This commit fixes the issue by adding `--unset-env=LD_PRELOAD` to the `finish-args` in the `flathub.json` manifest. This prevents the Flatpak runtime from trying to preload the problematic library, allowing the build to complete successfully and the application to run as expected.