### PR TITLE
fix: Add missing QStackedWidget import

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -8,7 +8,8 @@ import shutil
 from PyQt6.QtWidgets import (
     QApplication, QMainWindow, QWidget, QVBoxLayout, QHBoxLayout,
     QPushButton, QTableView, QStatusBar, QFileDialog, QMessageBox, QHeaderView,
-    QProgressBar, QComboBox, QLabel, QLineEdit, QSplitter, QTreeWidget, QTreeWidgetItem
+    QProgressBar, QComboBox, QLabel, QLineEdit, QSplitter, QTreeWidget, QTreeWidgetItem,
+    QStackedWidget
 )
 from PyQt6.QtCore import (
     QObject, QThread, pyqtSignal, QAbstractTableModel, Qt, QSortFilterProxyModel, QRegularExpression


### PR DESCRIPTION
This commit fixes a `NameError` that occurred at runtime because `QStackedWidget` was used in `ui.py` without being imported from `PyQt6.QtWidgets`.

This resolves the application crash reported in the previous turn.