### PR TITLE
fix: Fix UI crash and font rendering in Flatpak

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -18,7 +18,8 @@
             "buildsystem": "simple",
             "build-commands": [
                 "install -d /app/share/fonts/truetype/noto",
-                "install -m644 NotoColorEmoji-Regular.ttf /app/share/fonts/truetype/noto/NotoColorEmoji-Regular.ttf"
+                "install -m644 NotoColorEmoji-Regular.ttf /app/share/fonts/truetype/noto/NotoColorEmoji-Regular.ttf",
+                "fc-cache -f -v"
             ],
             "sources": [
                 {

--- a/ui.py
+++ b/ui.py
@@ -877,8 +877,11 @@ class MainWindow(QMainWindow):
 
     def update_context_pane_for_scan(self, strategy_id):
         # Clear the previous content
-        for i in reversed(range(self.scan_explanation_layout.count())):
-            self.scan_explanation_layout.itemAt(i).widget().setParent(None)
+        while self.scan_explanation_layout.count():
+            item = self.scan_explanation_layout.takeAt(0)
+            widget = item.widget()
+            if widget is not None:
+                widget.setParent(None)
 
         scenarios = ScenarioRunner.load_scenarios_config()
         scenario_data = next((s for s in scenarios if s['id'] == strategy_id), None)


### PR DESCRIPTION
This commit addresses two separate issues:

1.  Fixes an `AttributeError` in `ui.py` that occurred when clearing a layout containing a spacer. The layout clearing logic is now more robust and handles non-widget items correctly.

2.  Updates the `flathub.json` manifest to run `fc-cache` after installing the Noto Color Emoji font. This ensures the font cache is rebuilt within the sandbox, which should resolve the persistent glyph rendering errors.