### PR TITLE
This commit fixes two final bugs: a logic error in the `fundamental_d…

### DIFF
--- a/rebound_scenarios.py
+++ b/rebound_scenarios.py
@@ -23,6 +23,7 @@ from scoring import (
     passes_market_context_filter,
     DEFAULT_FUNDAMENTAL_WEIGHTS,
     DIVIDEND_SCENARIO_FUNDAMENTAL_WEIGHTS,
+    DIVERGENCE_SCENARIO_FUNDAMENTAL_WEIGHTS,
     DEFAULT_REBOUND_SCORE_WEIGHTS,
 )
 
@@ -827,6 +828,8 @@ class ScenarioRunner:
                             # Select the correct weights for the scenario
                             if scenario_id == 'high_quality_dividend':
                                 weights = DIVIDEND_SCENARIO_FUNDAMENTAL_WEIGHTS
+                            elif scenario_id == 'fundamental_divergence':
+                                weights = DIVERGENCE_SCENARIO_FUNDAMENTAL_WEIGHTS
                             else:
                                 weights = DEFAULT_FUNDAMENTAL_WEIGHTS
 

--- a/scoring.py
+++ b/scoring.py
@@ -40,6 +40,15 @@ DIVIDEND_SCENARIO_FUNDAMENTAL_WEIGHTS = {
     'revenue_3yr_cagr': 0.10,
 }
 
+# Special weights for the divergence scan, focusing on quality over valuation
+DIVERGENCE_SCENARIO_FUNDAMENTAL_WEIGHTS = {
+    'revenue_3yr_cagr': 0.25,
+    'eps_1y_growth': 0.25,
+    'roe': 0.20,
+    'free_cashflow_yield': 0.15,
+    'debt_equity': 0.15,
+}
+
 DEFAULT_REBOUND_SCORE_WEIGHTS = {
     'tech': 0.55,
     'fund': 0.30,

--- a/ui.py
+++ b/ui.py
@@ -540,7 +540,7 @@ class ScanCategoryCard(QFrame):
             btn = QPushButton(strategy['name'])
             btn.setObjectName("SubStrategyButton")
             btn.setCheckable(True)
-            btn.setAutoExclusive(True)
+            # setAutoExclusive is handled by the QButtonGroup in MainWindow
             btn.setStyleSheet("""
                 QPushButton#SubStrategyButton {
                     text-align: left;
@@ -588,6 +588,8 @@ class MainWindow(QMainWindow):
         self.results_df = pd.DataFrame()
         self.activeScan = None
         self.scan_cards = [] # To hold all card widgets
+        self.strategy_button_group = QButtonGroup(self)
+        self.strategy_button_group.setExclusive(True)
 
         # --- Layout and Widgets ---
         central_widget = QWidget()
@@ -874,11 +876,8 @@ class MainWindow(QMainWindow):
         self.results_df = pd.DataFrame()
         self.table_view.setModel(None)
 
-        # Uncheck buttons in all other cards
-        sender_card = self.sender()
-        for card in self.scan_cards:
-             if card is not sender_card:
-                card.uncheck_all()
+        # The QButtonGroup now handles unchecking other buttons automatically.
+        # No manual unchecking is needed.
 
         # Update the context pane
         self.update_context_pane_for_scan(strategy_id)
@@ -1017,6 +1016,8 @@ class MainWindow(QMainWindow):
                 sub_strategies=scenarios_in_group
             )
             card.strategySelected.connect(self.on_strategy_selected)
+            for btn in card.sub_strategy_buttons.values():
+                self.strategy_button_group.addButton(btn)
             self.card_layout.insertWidget(self.card_layout.count() - 1, card)
             self.scan_cards.append(card)
 


### PR DESCRIPTION
…ivergence` scenario and a UI bug with scenario selection.

1.  **Fix `fundamental_divergence` Logic:** The scenario was incorrectly filtering out valid candidates like `BSX`. This was because the fundamental score was being weighed down by valuation metrics (P/E, EV/EBIT), which is counter-intuitive for a "divergence" scan. A new set of fundamental weights (`DIVERGENCE_SCENARIO_FUNDAMENTAL_WEIGHTS`) has been created that focuses only on quality metrics (growth, ROE, debt). The `ScenarioRunner` now applies these specific weights when running this scan, ensuring the results better match the scenario's intent.

2.  **Fix UI Selection Bug:** When selecting a scan in a new category, the previously selected scan in another category would remain visually checked. This has been fixed by implementing a `QButtonGroup` in `MainWindow` to manage the exclusivity of all scenario buttons across all categories, which is a more robust and standard Qt approach. The flawed manual-unchecking logic has been removed.