### PR TITLE
fix(scanner): Correct scanner logic and multiple UI bugs

### DIFF
--- a/rebound_scenarios.py
+++ b/rebound_scenarios.py
@@ -591,9 +591,9 @@ class FundamentalDivergenceScenario(BaseScenario):
         if fundamental_data and 'metrics' in fundamental_data:
             prelim_fundamental_score, _ = compute_fundamental_score(
                 fundamentals=fundamental_data['metrics'], sector=fundamental_data.get('sector', 'N/A'),
-                sector_stats=sector_stats, weights=DEFAULT_FUNDAMENTAL_WEIGHTS)
+                sector_stats=sector_stats, weights=DIVERGENCE_SCENARIO_FUNDAMENTAL_WEIGHTS)
 
-        if prelim_fundamental_score < 50:
+        if prelim_fundamental_score < 45:
             return None
 
         stock_data = self._prepare_dataframe(stock_data)
@@ -811,6 +811,10 @@ class ScenarioRunner:
                 # Get all data for the current ticker
                 stock_info = get_ticker_info_cached(ticker_val)
                 if not passes_liquidity_filter(stock_info): continue
+
+                # FIX: Add the ticker to the info dict so scenarios can access it.
+                if stock_info:
+                    stock_info['ticker'] = ticker_val
 
                 stock_data = data_loader.get_stock_data(ticker_val)
                 if stock_data is None or stock_data.empty: continue


### PR DESCRIPTION
This commit resolves several issues preventing the scanner from functioning correctly and improves UI stability and usability.

The primary logical fix addresses the `FundamentalDivergenceScenario` not finding eligible candidates like 'BSX'. This was caused by a combination of a preliminary score threshold being too high and the check using the wrong fundamental weights.
- The preliminary score threshold has been lowered from 50 to 45.
- The preliminary check now correctly uses the `DIVERGENCE_SCENARIO_FUNDAMENTAL_WEIGHTS` instead of the default weights, aligning the check with the final score calculation.

Additionally, this commit includes fixes for several other bugs discovered during debugging:
- Resolves a `KeyError: 'ticker'` crash by ensuring the ticker symbol is always added to the `stock_info` dictionary used by scenarios.
- Fixes multiple `TypeError` crashes caused by calling Qt signals directly instead of using `.emit()` and by incorrect `super().__init__()` calls.
- Fixes a UI bug where multiple scan strategies could be selected simultaneously by implementing a `QButtonGroup` for exclusive selection.
- Replaces emoji characters in the UI with text to prevent font rendering errors in some Flatpak environments.
- Corrects the color of the error dialog text to ensure it is visible against the background.
- Fixes a `NameError` for `datetime` and `QButtonGroup` by adding the missing imports.
- Resolves an indentation error that prevented the `sector_medians.json` file from ever being created.