### PR TITLE
fix: Add missing files to Flatpak build manifest

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -53,7 +53,9 @@
                 "install -D data_loader.py /app/data_loader.py",
                 "install -D ticker_manager.py /app/ticker_manager.py",
                 "install -D config.py /app/config.py",
+                "install -D settings_manager.py /app/settings_manager.py",
                 "cp -r data /app/",
+                "cp -r styles /app/",
                 "install -D com.rectifex.GlobalReboundScreener.desktop /app/share/applications/com.rectifex.GlobalReboundScreener.desktop",
                 "install -D Rectifex_RB_Icon.svg /app/share/icons/hicolor/scalable/apps/com.rectifex.GlobalReboundScreener.svg"
             ],


### PR DESCRIPTION
This commit fixes a `ModuleNotFoundError: No module named 'settings_manager'` that occurred at runtime.

The error was caused by the `settings_manager.py` file and the `styles` directory not being included in the list of files to be installed in the `flathub.json` manifest.

The `flathub.json` file has been updated to include the necessary `install` and `cp` commands, ensuring all required files are present in the final application bundle.

This commit is made on top of the previous work that fixed the scanner logic and implemented the new settings page.