### PR TITLE
fix: Add missing pathlib import in ui.py

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -12,6 +12,7 @@ from PyQt6.QtWidgets import (
     QStackedWidget, QButtonGroup, QDialog, QDialogButtonBox, QCheckBox
 )
 from datetime import datetime
+from pathlib import Path
 from PyQt6.QtCore import (
     QObject, QThread, pyqtSignal, QAbstractTableModel, Qt, QSortFilterProxyModel, QRegularExpression
 )


### PR DESCRIPTION
This commit resolves a `NameError: name 'Path' is not defined` that occurred at application startup when trying to apply a theme.

The error was caused by using the `pathlib.Path` object in the `apply_theme` method without importing it first.

The `ui.py` file has been updated to include `from pathlib import Path`.

This fix is made on top of the previous work to fix the scanner logic, implement the settings page, and correct the Flatpak build manifest.