### PR TITLE
fix: Remove reference to deleted styles dir from build

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -55,7 +55,6 @@
                 "install -D config.py /app/config.py",
                 "install -D settings_manager.py /app/settings_manager.py",
                 "cp -r data /app/",
-                "cp -r styles /app/",
                 "install -D com.rectifex.GlobalReboundScreener.desktop /app/share/applications/com.rectifex.GlobalReboundScreener.desktop",
                 "install -D Rectifex_RB_Icon.svg /app/share/icons/hicolor/scalable/apps/com.rectifex.GlobalReboundScreener.svg"
             ],


### PR DESCRIPTION
This commit fixes a build failure that occurred because the `flathub.json` manifest was trying to copy the `styles` directory, which had been deleted as part of the dark mode removal.

The `cp -r styles /app/` command has been removed from the build commands to resolve the `cp: cannot stat 'styles': No such file or directory` error.