### PR TITLE
fix: Resolve crash on scan by fixing duplicate class definition

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -52,14 +52,6 @@ class TickerDetailSignals(QObject):
     result = pyqtSignal(object) # Emits the 'info' dict
 
 class AnalysisWorker(QObject):
-    """Defines the signals available from a running worker thread."""
-    finished = pyqtSignal()
-    error = pyqtSignal(tuple)
-    result = pyqtSignal(list)
-    progress = pyqtSignal(str)
-    progress_percent = pyqtSignal(int)
-
-class AnalysisWorker(QObject):
     """Worker thread for running the stock analysis to prevent GUI freezing."""
     def __init__(self, selected_scenario: str, ticker: str = None):
         super().__init__()
@@ -1115,72 +1107,6 @@ class MainWindow(QMainWindow):
             self.scan_explanation_layout.addStretch()
 
         self.context_stack.setCurrentIndex(0)
-
-    async def update_context_pane_for_ticker(self, candidate: ReboundCandidate):
-        # Clear the previous content
-        for i in reversed(range(self.ticker_detail_layout.count())):
-            self.ticker_detail_layout.itemAt(i).widget().setParent(None)
-
-        # Show loading message
-        loading_label = QLabel("Loading Ticker Details...")
-        self.ticker_detail_layout.addWidget(loading_label)
-        self.context_stack.setCurrentIndex(1)
-
-        # Fetch full data
-        if not hasattr(self, 'fund_handler'):
-            from fundamentals import FundamentalDataHandler
-            self.fund_handler = FundamentalDataHandler()
-
-        info = await self.fund_handler.get_full_ticker_info(candidate.ticker)
-
-        # Clear loading message
-        loading_label.setParent(None)
-
-        if not info:
-            error_label = QLabel(f"Could not load details for {candidate.ticker}.")
-            self.ticker_detail_layout.addWidget(error_label)
-            return
-
-        # Populate with new data
-        title = QLabel(f"<b>{info.get('shortName', candidate.ticker)}</b> ({candidate.ticker})")
-        title.setStyleSheet("font-size: 16px; margin-bottom: 5px;")
-
-        # TODO: Add a larger chart here later
-        chart_placeholder = QLabel("Chart will be here")
-        chart_placeholder.setMinimumHeight(150)
-        chart_placeholder.setStyleSheet("background-color: #e0e0e0; border: 1px solid #ccc;")
-        chart_placeholder.setAlignment(Qt.AlignmentFlag.AlignCenter)
-
-        # Key metrics
-        def format_market_cap(mc):
-            if mc is None: return "N/A"
-            if mc > 1_000_000_000_000: return f"${mc/1_000_000_000_000:.2f}T"
-            if mc > 1_000_000_000: return f"${mc/1_000_000_000:.2f}B"
-            if mc > 1_000_000: return f"${mc/1_000_000:.2f}M"
-            return f"${mc}"
-
-        pe_ratio = f"{info.get('trailingPE'):.2f}" if info.get('trailingPE') else "N/A"
-        div_yield = f"{info.get('dividendYield')*100:.2f}%" if info.get('dividendYield') else "N/A"
-
-        metrics_text = (
-            f"<b>Market Cap:</b> {format_market_cap(info.get('marketCap'))}<br>"
-            f"<b>P/E Ratio:</b> {pe_ratio}<br>"
-            f"<b>Dividend Yield:</b> {div_yield}"
-        )
-        metrics_label = QLabel(metrics_text)
-
-        # Company Bio
-        bio_title = QLabel("<b>Company Bio</b>")
-        bio_title.setStyleSheet("color: #005a9e; margin-top: 10px;")
-        bio_text = QLabel(info.get('longBusinessSummary', 'No company summary available.'))
-        bio_text.setWordWrap(True)
-
-        self.ticker_detail_layout.addWidget(title)
-        self.ticker_detail_layout.addWidget(chart_placeholder)
-        self.ticker_detail_layout.addWidget(metrics_label)
-        self.ticker_detail_layout.addWidget(bio_title)
-        self.ticker_detail_layout.addWidget(bio_text)
-        self.ticker_detail_layout.addStretch()
 
     def populate_strategy_cards(self):
         """


### PR DESCRIPTION
This commit fixes a critical crash that occurred when the user clicked the 'Run Scan' button.

The crash was caused by a duplicate `AnalysisWorker` class definition in `ui.py`, which was a result of a previous faulty refactoring. This led to an unstable state and a likely segmentation fault when the worker thread was initialized.

This commit resolves the issue by:
1. Removing the extraneous, incorrect `AnalysisWorker` class definition.
2. Removing the now-unnecessary `update_context_pane_for_ticker` method, which was also a remnant of a previous refactoring.

With this change, the application should no longer crash when initiating a scan.