### PR TITLE
fix: Correct typo in QtWidgets import

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -7,7 +7,7 @@ import pandas as pd
 import shutil
 from PyQt6.QtWidgets import (
     QApplication, QMainWindow, QWidget, QVBoxLayout, QHBoxLayout,
-    QPushButton, QTableView, QStatusBar, QFileDialog, QMessageBox, QHeaderV,
+    QPushButton, QTableView, QStatusBar, QFileDialog, QMessageBox, QHeaderView,
     QProgressBar, QComboBox, QLabel, QLineEdit, QSplitter, QTreeWidget, QTreeWidgetItem,
     QStackedWidget, QButtonGroup, QDialog, QDialogButtonBox, QCheckBox
 )


### PR DESCRIPTION
This commit fixes a critical `ImportError` that prevented the application from starting.

The error was caused by a typo in `ui.py` where `QHeaderView` was incorrectly written as `QHeaderV`. This has been corrected.

This finalizes the work on stabilizing the UI and implementing the i18n framework.