### PR TITLE
feat: Align table text to left and center vertically

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -130,8 +130,7 @@ class PandasModel(QAbstractTableModel):
         if role == Qt.ItemDataRole.EditRole:
             return self._data.iloc[row, col]
         if role == Qt.ItemDataRole.TextAlignmentRole:
-            if column_name in self.numeric_columns:
-                return Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter
+            return Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter
         if role == Qt.ItemDataRole.BackgroundRole:
             if "Rebound Score" in self._data.columns:
                 score = self._data.iloc[row]["Rebound Score"]


### PR DESCRIPTION
This commit addresses the user's final UI adjustment request.

The `PandasModel.data` method in `ui.py` has been modified to set the text alignment for all columns in the results table to `AlignLeft` and `AlignVCenter`. This provides a more uniform and readable presentation of the scan results.

This concludes the series of fixes and feature implementations.