### PR TITLE
feat: Center-align table text

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -130,7 +130,7 @@ class PandasModel(QAbstractTableModel):
         if role == Qt.ItemDataRole.EditRole:
             return self._data.iloc[row, col]
         if role == Qt.ItemDataRole.TextAlignmentRole:
-            return Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter
+            return Qt.AlignmentFlag.AlignCenter
         if role == Qt.ItemDataRole.BackgroundRole:
             if "Rebound Score" in self._data.columns:
                 score = self._data.iloc[row]["Rebound Score"]


### PR DESCRIPTION
This commit addresses the user's final UI adjustment request.

The `PandasModel.data` method in `ui.py` has been modified to set the text alignment for all columns in the results table to `Qt.AlignmentFlag.AlignCenter`. This will center the text both horizontally and vertically in the cell.

This concludes the series of fixes and feature implementations.