### PR TITLE
fix: Add missing datetime import in ui.py

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -5,6 +5,7 @@ import sys
 import logging
 import pandas as pd
 import shutil
+from datetime import datetime
 from PyQt6.QtWidgets import (
     QApplication, QMainWindow, QWidget, QVBoxLayout, QHBoxLayout,
     QPushButton, QTableView, QStatusBar, QFileDialog, QMessageBox, QHeaderView,


### PR DESCRIPTION
This commit fixes a `NameError: name 'datetime' is not defined` that occurred when displaying scan results. The error was caused by using `datetime.now()` without the corresponding import.

This has been resolved by adding `from datetime import datetime` to `ui.py`.

This is a critical fix to prevent the application from crashing after a successful scan.