### PR TITLE
Fix: Resolve crash when selecting a scan scenario

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -408,11 +408,9 @@ class MainWindow(QMainWindow):
     def on_strategy_selected(self, strategy_id):
         self.activeScan = strategy_id; self.stacked_widget.setCurrentIndex(0)
         self.results_df = pd.DataFrame(); self.table_view.setModel(None)
-        sender_button = self.sender()
-        if sender_button:
-            parent_card = sender_button.parent()
-            for card in self.scan_cards:
-                if card is not parent_card: card.uncheck_all()
+        # The QButtonGroup handles unchecking other buttons automatically.
+        # The removed code here was redundant and causing a crash because
+        # the 'uncheck_all' method does not exist.
         self.update_context_pane_for_scan(strategy_id)
     def update_context_pane_for_scan(self, strategy_id):
         while self.scan_explanation_layout.count():


### PR DESCRIPTION
This commit addresses a crash that occurred when a user clicked on any of the scan scenario buttons.

The root cause was an `AttributeError` in the `on_strategy_selected` method in `ui.py`. The method was attempting to call a non-existent `uncheck_all` method on `ScanCategoryCard` instances.

This block of code was found to be redundant. The exclusivity of the scenario selection is already correctly managed by the `strategy_button_group` (a `QButtonGroup`), which automatically handles the visual deselection of other radio buttons.

The fix removes the superfluous and buggy code block, allowing the `QButtonGroup` to manage the state as intended and preventing the crash.