### PR TITLE
Fix NameError crash when displaying scan results.

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -5,6 +5,7 @@ import sys
 import logging
 import pandas as pd
 import shutil
+import datetime
 from PyQt6.QtWidgets import (
     QApplication, QMainWindow, QWidget, QVBoxLayout, QHBoxLayout,
     QPushButton, QTableView, QStatusBar, QFileDialog, QMessageBox, QHeaderView,


### PR DESCRIPTION
The application would crash with a `NameError: name 'datetime' is not defined` when a scan completed successfully. This was because `datetime.now()` was being called in `ui.py` to update a label, but the `datetime` module was not imported.

This commit adds the required `import datetime` statement to the top of `ui.py`, resolving the crash.