### PR TITLE
Correct the datetime import to fix AttributeError

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -5,7 +5,7 @@ import sys
 import logging
 import pandas as pd
 import shutil
-import datetime
+from datetime import datetime
 from PyQt6.QtWidgets import (
     QApplication, QMainWindow, QWidget, QVBoxLayout, QHBoxLayout,
     QPushButton, QTableView, QStatusBar, QFileDialog, QMessageBox, QHeaderView,


### PR DESCRIPTION
The previous commit fixed a `NameError` by adding `import datetime`, but this was incorrect. It caused a subsequent `AttributeError: module 'datetime' has no attribute 'now'`.

This commit corrects the import statement to `from datetime import datetime`, which imports the `datetime` class directly. This allows the call to `datetime.now()` to work as intended and resolves the crash.