### PR TITLE
fix: Prevent caching of empty dataframes to fix chart rendering

### DIFF
--- a/data_loader.py
+++ b/data_loader.py
@@ -241,6 +241,10 @@ async def get_stock_data(ticker: str) -> pd.DataFrame | None:
         # Drop rows with NaN values which can be returned by yfinance
         data.dropna(inplace=True)
 
+        if data.empty:
+            logging.warning(f"DataFrame for {ticker} is empty after dropping NaNs. Not caching.")
+            return None
+
         # Save to cache in an executor as well to avoid blocking
         save_func = functools.partial(data.to_csv, cache_file)
         await loop.run_in_executor(None, save_func)

--- a/ui.py
+++ b/ui.py
@@ -312,14 +312,6 @@ class ChartWindow(QWidget):
             else:
                 plot_data = history_df.copy()
 
-            # --- DEBUG LOGGING ---
-            logging.info(f"--- Chart Data Debug for {candidate.ticker} ---")
-            logging.info(f"Plot data shape: {plot_data.shape}")
-            logging.info(f"Plot data head:\n{plot_data.head()}")
-            logging.info(f"Plot data tail:\n{plot_data.tail()}")
-            logging.info(f"Plot data nulls:\n{plot_data.isnull().sum()}")
-            logging.info("--- End Chart Data Debug ---")
-
             # --- Indicator Calculations ---
             if 'SMA50' not in plot_data.columns:
                 plot_data['SMA50'] = calculate_sma(plot_data['Close'], 50)


### PR DESCRIPTION
This commit provides a definitive fix for the bug where charts would render as blank for certain tickers.

The root cause was identified in `data_loader.py`. For some tickers, `yfinance` would return data that, after processing (specifically after `dropna()`), would result in an empty DataFrame. This empty DataFrame was then incorrectly saved to the cache. Subsequent attempts to view a chart for that ticker would load the empty cached file, leading to the blank plot.

The fix is to add a check in `get_stock_data` after the `dropna()` call. If the DataFrame is empty at this point, a warning is logged, and `None` is returned, preventing the empty data from being cached and propagated through the application.

This commit also removes the temporary diagnostic logging that was added to `ui.py` in the previous commit.