### PR TITLE
fix: Prevent crash when clearing cache from settings dialog

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -583,7 +583,12 @@ class AdvancedSettingsDialog(QDialog):
             try:
                 shutil.rmtree(config.CACHE_DIR)
                 config.CACHE_DIR.mkdir(parents=True, exist_ok=True)
-                QMessageBox.information(self, "Success", "Cache successfully cleared.")
+                # Use the main window's status bar for notifications to avoid instability.
+                main_window = self.parent()
+                if main_window and hasattr(main_window, 'status_bar'):
+                    main_window.status_bar.showMessage("Cache successfully cleared.", 5000)
+                else:
+                    QMessageBox.information(self, "Success", "Cache successfully cleared.")
             except Exception as e:
                 QMessageBox.critical(self, "Cache Error", f"Failed to clear cache: {e}")
 


### PR DESCRIPTION
This commit fixes a bug where the application would crash after the user confirmed the "Clear Cache" action from within the new Advanced Settings dialog.

The crash was likely caused by creating a new `QMessageBox` for the success confirmation immediately after a significant filesystem operation (`shutil.rmtree`).

The fix reverts the notification logic to the original, more stable implementation. The `clear_cache` method now accesses its parent (the `MainWindow`) and uses its existing `status_bar` to display the confirmation message, avoiding the creation of a new top-level window at a potentially unstable moment.