### PR TITLE
Fix settings crash and chart rendering issues

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -414,6 +414,9 @@ class ChartWindow(QWidget):
                      xrotation=20,
                      hlines=hlines_fib if hlines_fib else None)
 
+            # Manually set x-axis limits to fit the data, which fixes the squished chart issue.
+            price_ax.set_xlim(plot_data.index[0], plot_data.index[-1])
+
             # --- Add Fibonacci Labels ---
             if fib_levels:
                 # Use a transform that combines data y-coords with axes x-coords
@@ -441,7 +444,7 @@ class ChartWindow(QWidget):
 
             # --- Final Styling ---
             self.figure.suptitle(f'{candidate.ticker} - {candidate.scenario}', y=0.98)
-            price_ax.legend(loc='upper left')
+            # price_ax.legend(loc='upper left') # Removed to prevent UserWarning as mplfinance handles MA legends.
             rsi_ax.set_ylabel('RSI')
             macd_ax.set_ylabel('MACD')
 


### PR DESCRIPTION
This commit addresses two issues:
1. A crash when opening the settings dialog.
2. Multiple rendering problems in the stock charts.

The settings dialog crash was caused by an OverflowError when setting a large value on a QSpinBox. This has been resolved by replacing it with a QDoubleSpinBox. The 'Clear Cache' button in this dialog has also been correctly connected.

The chart rendering problems, including squished data and misaligned axes, have been fixed by manually setting the x-axis limits after plotting the data. A redundant legend call that was causing a UserWarning has also been removed.