### PR TITLE
fix: Pin pandas-ta to a compatible version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ openpyxl
 matplotlib
 mplfinance
 aiohttp
-pandas-ta
+pandas-ta==0.3.14b


### PR DESCRIPTION
This commit pins the `pandas-ta` library to version 0.3.14b to ensure compatibility with the Python 3.11 environment used in the Flatpak build. This resolves the `ModuleNotFoundError` that occurred during the build process.