### PR TITLE
fix(ui): Resolve AttributeError by setting runner on AnalysisWorker

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -52,22 +52,26 @@ class AnalysisWorker(QObject):
         self.selected_scenario = selected_scenario
         self.ticker = ticker
         self._is_cancelled = False
+        self.runner = None # Initialize runner attribute
 
     def cancel(self):
         """Sets the cancellation flag to True."""
         logging.info("Cancellation requested for worker.")
         self._is_cancelled = True
+        if self.runner:
+            self.runner.cancel()
+
 
     def run(self):
         """Runs the analysis and emits signals for progress and completion."""
         try:
-            runner = ScenarioRunner(
+            self.runner = ScenarioRunner(
                 progress_callback=self.signals.progress,
                 progress_percent_callback=self.signals.progress_percent,
                 is_cancelled_callback=lambda: self._is_cancelled
             )
-            results = asyncio.run(runner.run_scan(self.selected_scenario, ticker=self.ticker))
-            self.signals.result.emit(results, runner.telemetry)
+            results = asyncio.run(self.runner.run_scan(self.selected_scenario, ticker=self.ticker))
+            self.signals.result.emit(results, self.runner.telemetry)
         except Exception as e:
             import traceback
             self.signals.error.emit((type(e), e, traceback.format_exc()))


### PR DESCRIPTION
The application was crashing during a scan because the `update_status_text` method tried to access `self.worker.runner`, but `runner` was a local variable in the `AnalysisWorker.run` method, not an instance attribute.

This commit fixes the bug by:
1. Initializing `self.runner = None` in the `AnalysisWorker` constructor.
2. Assigning the `ScenarioRunner` instance to `self.runner` in the `run` method.
3. Adding a call to `self.runner.cancel()` in the `cancel` method to properly propagate the cancellation request.