### PR TITLE
fix: Prevent crashes from AttributeError and TypeError during scans

### DIFF
--- a/rebound_scenarios.py
+++ b/rebound_scenarios.py
@@ -180,6 +180,12 @@ class ScenarioRunner:
                 if self.is_cancelled(): break
 
                 stock_info = get_ticker_info_cached(ticker_val)
+                if stock_info is None:
+                    logging.warning(f"Could not retrieve stock info for {ticker_val}, skipping.")
+                    self.telemetry['tickers_skipped']['total'] += 1
+                    self.telemetry['tickers_skipped']['other'] += 1
+                    continue
+
                 if not passes_liquidity_filter(stock_info):
                     self.telemetry['tickers_skipped']['total'] += 1; self.telemetry['tickers_skipped']['liquidity'] += 1; continue
 


### PR DESCRIPTION
This commit resolves two critical bugs that caused the application to crash when a scan was initiated.

The first bug was an `AttributeError: 'AnalysisWorker' object has no attribute 'runner'`. This occurred because the `runner` object was scoped as a local variable within the `AnalysisWorker.run` method, making it inaccessible to other methods like `update_status_text`. The fix promotes `runner` to an instance attribute (`self.runner`), ensuring it is accessible throughout the worker's lifecycle.

The second bug was a `TypeError: 'NoneType' object is not subscriptable`. This happened because the `get_ticker_info_cached` function could return `None` for certain tickers, and the application did not handle this case, leading to a crash. A check has been added to `rebound_scenarios.py` to verify that `stock_info` is not `None` before attempting to use it, allowing the scan to gracefully skip tickers with missing information.