### PR TITLE
fix: Handle yfinance ValueError for empty arrays

### DIFF
--- a/fundamentals.py
+++ b/fundamentals.py
@@ -82,6 +82,11 @@ class FundamentalDataHandler:
                 self._save_to_cache(ticker, data_packet)
                 return data_packet
             except Exception as e:
+                # This specific yfinance error is not transient, so we shouldn't retry.
+                if isinstance(e, ValueError) and "The truth value of an empty array is ambiguous" in str(e):
+                    logging.warning(f"Skipping {ticker} due to a yfinance internal data error: {e}")
+                    return None
+
                 logging.warning(f"Attempt {attempt + 1} for {ticker} failed: {e}")
                 if attempt < max_retries - 1:
                     wait_time = base_wait_time * (2 ** attempt) + random.uniform(0, 1)


### PR DESCRIPTION
The `yfinance` library can raise a `ValueError` with the message "The truth value of an empty array is ambiguous" when fetching data for certain tickers. This error is not transient and causes the application to retry unnecessarily, flooding the logs with warnings and preventing scans from completing.

This change modifies the exception handling in `fundamentals.py` to specifically catch this `ValueError`. When this error is detected, it logs a warning and skips the problematic ticker instead of retrying, allowing the scan to proceed with the remaining tickers.