### PR TITLE
fix: Handle ambiguous yfinance ValueError during data fetching

### DIFF
--- a/fundamentals.py
+++ b/fundamentals.py
@@ -83,7 +83,7 @@ class FundamentalDataHandler:
                 return data_packet
             except Exception as e:
                 # This specific yfinance error is not transient, so we shouldn't retry.
-                if isinstance(e, ValueError) and "The truth value of an empty array is ambiguous" in str(e):
+                if isinstance(e, ValueError) and "The truth value of an" in str(e) and "is ambiguous" in str(e):
                     logging.warning(f"Skipping {ticker} due to a yfinance internal data error: {e}")
                     return None
 


### PR DESCRIPTION
This commit broadens the exception handling in `fundamentals.py` to catch all `ValueError` exceptions from the `yfinance` library that relate to the ambiguous truth value of an array. This includes both "empty array" and "array with more than one element" scenarios.

Previously, only the "empty array" case was handled, leading to crashes when the latter case occurred. The updated logic now checks for the common pattern "The truth value of an ... is ambiguous" in the error message, ensuring that any such non-transient data error from `yfinance` results in the ticker being gracefully skipped rather than causing the application to crash or enter a pointless retry loop.