### PR TITLE
fix: Handle all non-transient yfinance data errors

### DIFF
--- a/data_loader.py
+++ b/data_loader.py
@@ -191,6 +191,7 @@ async def _fetch_single_ticker_history(ticker: str) -> pd.DataFrame | None:
             # Handle non-transient errors by skipping the ticker immediately
             if ('YFPricesMissingError' in error_str or
                 'No data found, symbol may be delisted' in error_str or
+                'No objects to concatenate' in error_str or
                 (isinstance(e, ValueError) and "The truth value of an" in error_str and "is ambiguous" in error_str)):
                 logging.warning(f"Skipping {ticker} due to a non-transient data error: {e}")
                 return None  # Do not retry for these errors


### PR DESCRIPTION
This commit provides a comprehensive fix for multiple non-transient errors originating from the `yfinance` library during data fetching, which caused the application to crash or get stuck in retry loops.

The following issues have been addressed in both `data_loader.py` (for historical data) and `fundamentals.py` (for fundamental data):

1.  **Ambiguous `ValueError`**: Catches `ValueError` exceptions where the message contains "The truth value of an ... is ambiguous". This covers both "empty array" and "array with more than one element" scenarios.

2.  **Missing Price Data**: Catches errors indicating that a ticker may be delisted or has no price data available (e.g., `YFPricesMissingError`).

3.  **Concatenation Errors**: Catches `ValueError` exceptions with the message "No objects to concatenate", which occurs when `yfinance` returns no data.

For any of these non-transient errors, the application will now log a warning and gracefully skip the problematic ticker instead of retrying, allowing the overall scanning process to complete successfully.