### PR TITLE
fix: Suppress yfinance logger to hide handled errors

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,12 +2,16 @@
 # Entry point for the Rectifex RB application.
 
 import sys
+import logging
 from PyQt6.QtWidgets import QApplication
 from ui import MainWindow
 import config
 
 def main():
     """Main function to run the application."""
+    # Suppress yfinance's noisy error logs for handled exceptions
+    logging.getLogger('yfinance').setLevel(logging.CRITICAL)
+
     # Ensure the cache directory exists before starting
     try:
         config.CACHE_DIR.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
This commit suppresses the `yfinance` logger by setting its level to `CRITICAL` in `main.py`.

Previous commits established robust error handling for various non-transient data errors from the `yfinance` library (e.g., ambiguous ValueErrors, missing price data, concatenation errors). While the application now correctly handles these exceptions and skips problematic tickers, the `yfinance` library itself still logs them as `ERROR`s.

This creates confusing and noisy log output, suggesting that there are unhandled errors when, in fact, the application is functioning as intended. By suppressing the logger, we only see the application's own warnings about skipped tickers, which provides a much clearer picture of the process.