### PR TITLE
Fix fundamental score weighting when sector stats missing

### DIFF
--- a/scoring.py
+++ b/scoring.py
@@ -104,7 +104,7 @@ def compute_fundamental_score(
     """
     total_score = 0.0
     total_weight = 0.0
-    breakdown = {}
+    breakdown: Dict[str, Any] = {}
 
     sector_data = sector_stats.get(sector, {})
     sector_median_values = sector_data.get('medians', {})
@@ -113,9 +113,10 @@ def compute_fundamental_score(
     for metric, weight in weights.items():
         value = fundamentals.get(metric)
         if value is None:
+            breakdown[f"{metric}_sub_score"] = None
             continue
 
-        sub_score = 0
+        sub_score: Optional[int]
         if metric == 'payout_ratio':
             # Special handling for bounded metrics like payout ratio
             sub_score = normalize_bounded_metric(value, ideal_range=(0.15, 0.50), acceptable_range=(0.0, 0.80))
@@ -124,9 +125,12 @@ def compute_fundamental_score(
             median = sector_median_values.get(metric)
             std_dev = sector_std_devs.get(metric)
 
-            if median is not None and std_dev is not None:
-                higher_is_better = metric in HIGHER_IS_BETTER_METRICS
-                sub_score = metric_to_subscore(value, median, std_dev, higher_is_better)
+            if median is None or std_dev is None:
+                breakdown[f"{metric}_sub_score"] = None
+                continue
+
+            higher_is_better = metric in HIGHER_IS_BETTER_METRICS
+            sub_score = metric_to_subscore(value, median, std_dev, higher_is_better)
 
         breakdown[f"{metric}_sub_score"] = sub_score
         total_score += sub_score * weight

--- a/test_scoring.py
+++ b/test_scoring.py
@@ -96,6 +96,29 @@ class TestScoring(unittest.TestCase):
         self.assertEqual(breakdown['roe_sub_score'], 57)
         self.assertEqual(breakdown['debt_equity_sub_score'], 57)
 
+    def test_compute_fundamental_score_ignores_missing_sector_stats(self):
+        fundamentals = {'revenue_3yr_cagr': 0.20, 'roe': 0.25}
+        weights = {'revenue_3yr_cagr': 0.6, 'roe': 0.4}
+        # Sector stats missing entries for ROE
+        sector_stats = {
+            'Technology': {
+                'medians': {'revenue_3yr_cagr': 0.10},
+                'std_devs': {'revenue_3yr_cagr': 0.05}
+            }
+        }
+
+        fund_score, breakdown = compute_fundamental_score(
+            fundamentals=fundamentals,
+            sector='Technology',
+            sector_stats=sector_stats,
+            weights=weights
+        )
+
+        # Only revenue_3yr_cagr should contribute since ROE lacks sector stats
+        self.assertEqual(fund_score, 70)
+        self.assertEqual(breakdown['revenue_3yr_cagr_sub_score'], 70)
+        self.assertIsNone(breakdown['roe_sub_score'])
+
     def test_compute_rebound_score(self):
         weights = {'tech': 0.55, 'fund': 0.30, 'market': 0.15}
         score = compute_rebound_score(tech_score=75, fund_score=57, market_score=50, weights=weights)


### PR DESCRIPTION
## Summary
- avoid penalizing tickers for missing sector statistics when computing fundamental scores
- record unavailable sub-scores in the breakdown for clarity and add regression coverage

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d780b82ea8832f81f28d8f1edf8c56