### PR TITLE
Normalize share-class tickers before calling yfinance

### DIFF
--- a/data_loader.py
+++ b/data_loader.py
@@ -16,6 +16,7 @@ from io import StringIO
 
 # Assuming config.py is in the same directory
 import config
+from ticker_utils import normalize_ticker_for_yfinance
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
@@ -27,10 +28,18 @@ async def fetch_history(ticker, period='1y', retries=2, backoff=1):
     Robust, truly asynchronous yfinance fetch.
     """
     loop = asyncio.get_running_loop()
+    fetch_ticker = normalize_ticker_for_yfinance(ticker)
     for attempt in range(retries + 1):
         try:
             # 1) Try yf.download
-            download_func = functools.partial(yf.download, ticker, period=period, threads=False, progress=False, auto_adjust=True)
+            download_func = functools.partial(
+                yf.download,
+                fetch_ticker,
+                period=period,
+                threads=False,
+                progress=False,
+                auto_adjust=True,
+            )
             df = await loop.run_in_executor(None, download_func)
 
             if df is not None and not df.empty:
@@ -42,7 +51,7 @@ async def fetch_history(ticker, period='1y', retries=2, backoff=1):
 
             # 2) Fallback to Ticker.history
             # yf.Ticker() itself can be slow, so run it in the executor too
-            ticker_func = functools.partial(yf.Ticker, ticker)
+            ticker_func = functools.partial(yf.Ticker, fetch_ticker)
             tk = await loop.run_in_executor(None, ticker_func)
             history_func = functools.partial(tk.history, period=period, auto_adjust=True)
             df2 = await loop.run_in_executor(None, history_func)
@@ -55,7 +64,10 @@ async def fetch_history(ticker, period='1y', retries=2, backoff=1):
                 return df2
 
         except Exception as e:
-            logger.warning(f"yfinance fetch error for {ticker} (attempt {attempt + 1}): {e}", exc_info=False)
+            logger.warning(
+                f"yfinance fetch error for {ticker} (attempt {attempt + 1}) using symbol {fetch_ticker}: {e}",
+                exc_info=False,
+            )
 
         if attempt < retries:
             wait_time = backoff * (2 ** attempt)

--- a/fundamentals.py
+++ b/fundamentals.py
@@ -12,6 +12,7 @@ import yfinance as yf
 # from curl_cffi.requests import AsyncSession # This was causing issues
 
 import config
+from ticker_utils import normalize_ticker_for_yfinance
 import time
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
@@ -25,14 +26,15 @@ async def _fetch_single_ticker_fundamentals(ticker: str) -> Optional[Dict[str, A
     loop = asyncio.get_running_loop()
     max_retries = 3
     base_wait_time = 2
+    fetch_ticker = normalize_ticker_for_yfinance(ticker)
     for attempt in range(max_retries):
         try:
             # yf.Ticker and .info are blocking calls, run in executor
-            stock = await loop.run_in_executor(None, yf.Ticker, ticker)
+            stock = await loop.run_in_executor(None, yf.Ticker, fetch_ticker)
             info = await loop.run_in_executor(None, getattr, stock, 'info')
 
             if not isinstance(info, dict) or not info:
-                logger.warning(f"No valid info dictionary returned for {ticker}, skipping.")
+                logger.warning(f"No valid info dictionary returned for {ticker} (queried as {fetch_ticker}), skipping.")
                 return None
 
             # Process the info dict to make it serializable and handle numpy arrays/series

--- a/scrape_tickers.py
+++ b/scrape_tickers.py
@@ -5,6 +5,8 @@ import requests
 from io import StringIO
 from pathlib import Path
 
+from ticker_utils import normalize_ticker_for_yfinance
+
 def verify_and_save_tickers(index_name: str, tickers_to_verify: list, output_filename: str):
     """
     Verifies a list of tickers using yfinance and saves the valid ones to a CSV file.
@@ -17,9 +19,11 @@ def verify_and_save_tickers(index_name: str, tickers_to_verify: list, output_fil
         if not cleaned_ticker:
             continue
 
+        fetch_ticker = normalize_ticker_for_yfinance(cleaned_ticker)
+
         print(f"Verifying [{i+1}/{len(tickers_to_verify)}]: {cleaned_ticker}...", end='', flush=True)
         try:
-            stock = yf.Ticker(cleaned_ticker)
+            stock = yf.Ticker(fetch_ticker)
             hist = stock.history(period="5d")
             if not hist.empty:
                 print(" -> VALID")

--- a/ticker_utils.py
+++ b/ticker_utils.py
@@ -1,0 +1,41 @@
+"""Utility helpers for working with ticker symbols."""
+
+from __future__ import annotations
+
+import re
+
+# Pre-compile a regex for share-class tickers that Yahoo expects with hyphen.
+_SHARE_CLASS_PATTERN = re.compile(r"^(?P<base>[A-Z0-9]+)\.(?P<class>[A-Z])$")
+
+
+def normalize_ticker_for_yfinance(ticker: str) -> str:
+    """Return a Yahoo Finance compatible ticker symbol.
+
+    Yahoo uses hyphen separators for share-class tickers such as ``BRK.B`` or
+    ``BF.B`` while exchange suffixes (e.g. ``.DE``, ``.T``) retain their dot.
+    The Flatpak build was emitting repeated fetch errors for tickers that
+    include a dot because they were forwarded to :mod:`yfinance` unchanged.
+    This helper normalises the known share-class pattern so that the rest of
+    the codebase can continue using the canonical dot notation everywhere else.
+
+    Parameters
+    ----------
+    ticker:
+        The ticker symbol provided by the user or configuration. The helper is
+        intentionally conservative and only rewrites the subset of symbols that
+        Yahoo requires with a hyphen. All other symbols are returned verbatim
+        so that region/exchange suffixes remain intact.
+    """
+    if not ticker:
+        return ticker
+
+    cleaned = ticker.strip()
+    if not cleaned:
+        return cleaned
+
+    match = _SHARE_CLASS_PATTERN.match(cleaned.upper())
+    if match:
+        return f"{match.group('base')}-{match.group('class')}"
+
+    return cleaned
+


### PR DESCRIPTION
## Summary
- add a shared ticker normalization helper that converts share-class dots to hyphens for Yahoo Finance
- apply the normalization when downloading historical prices, fetching fundamentals, and verifying scraped tickers
- improve logging to clarify the original versus normalized ticker used during retries

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d7863b8820832f9ed52854ae4812d7