### PR TITLE
Ensure ticker_utils ships with Flatpak build

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -51,6 +51,7 @@
                 "install -D scenarios.json /app/scenarios.json",
                 "install -D rebound_scenarios.py /app/rebound_scenarios.py",
                 "install -D data_loader.py /app/data_loader.py",
+                "install -D ticker_utils.py /app/ticker_utils.py",
                 "install -D ticker_manager.py /app/ticker_manager.py",
                 "install -D config.py /app/config.py",
                 "install -D settings_manager.py /app/settings_manager.py",


### PR DESCRIPTION
## Summary
- add ticker_utils.py to the Flatpak install commands so it is bundled at runtime

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d78794a414832f98cb16cc6d424f93