### PR TITLE
Disable debug stripping logs in Flatpak build

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -36,7 +36,9 @@
             "build-options": {
                 "build-args": [
                     "--share=network"
-                ]
+                ],
+                "strip": false,
+                "no-debuginfo": true
             },
             "build-commands": [
                 "pip3 install --prefix=/app --no-cache-dir numpy",


### PR DESCRIPTION
## Summary
- disable stripping and debug info extraction for the application module to reduce noisy Flatpak build logs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d794787410832f8bf1f7874bdf3825