### PR TITLE
Improve yfinance history fetching resilience

### DIFF
--- a/config.py
+++ b/config.py
@@ -63,6 +63,10 @@ FAILED_HISTORY_CACHE_EXPIRY_HOURS = 6  # Remember failed price fetches for 6 hou
 
 # -- Data Loading Configuration --
 DATA_PERIOD = "18mo" # Download 18 months of historical data
+MINIMUM_HISTORY_PERIOD = "6mo"  # Short requests are automatically extended to at least six months
+MIN_FALLBACK_HISTORY_DAYS = 180  # Explicit date-range retries request at least ~six months of data
+YFINANCE_THROTTLE_SECONDS = 1.0  # Delay between yfinance requests to avoid rate limiting
+VALIDATION_HISTORY_PERIOD = "6mo"  # Period used for the quick validation step
 SAFE_GET_DEFAULT = None # Default value for the safe_get utility
 
 # -- Analysis & Filtering Criteria --

--- a/data_loader.py
+++ b/data_loader.py
@@ -23,6 +23,9 @@ logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(
 logger = logging.getLogger(__name__)
 
 FAILURE_CACHE_EXPIRY_HOURS = getattr(config, "FAILED_HISTORY_CACHE_EXPIRY_HOURS", 6)
+_MINIMUM_HISTORY_PERIOD = getattr(config, "MINIMUM_HISTORY_PERIOD", None)
+_MIN_FALLBACK_HISTORY_DAYS = getattr(config, "MIN_FALLBACK_HISTORY_DAYS", 180)
+_REQUEST_THROTTLE_SECONDS = getattr(config, "YFINANCE_THROTTLE_SECONDS", 0.0)
 _last_failed_tickers: Dict[str, Dict[str, str]] = {}
 
 
@@ -82,7 +85,24 @@ async def fetch_history(ticker, period='1y', retries=2, backoff=1) -> Tuple[pd.D
     last_error: str | None = None
     attempts = 0
 
-    history_kwargs = _build_history_kwargs(period)
+    requested_period = period
+    effective_period = period
+    if _MINIMUM_HISTORY_PERIOD:
+        min_period_delta = _period_to_timedelta(_MINIMUM_HISTORY_PERIOD)
+        if not effective_period:
+            effective_period = _MINIMUM_HISTORY_PERIOD
+        else:
+            current_delta = _period_to_timedelta(effective_period)
+            if current_delta < min_period_delta:
+                logger.debug(
+                    "Extending history request for %s from %s to %s to ensure sufficient data.",
+                    ticker,
+                    effective_period,
+                    _MINIMUM_HISTORY_PERIOD,
+                )
+                effective_period = _MINIMUM_HISTORY_PERIOD
+
+    history_kwargs = _build_history_kwargs(effective_period)
     fallback_context: Dict[str, str] | None = None
 
     for attempt in range(retries + 1):
@@ -130,9 +150,13 @@ async def fetch_history(ticker, period='1y', retries=2, backoff=1) -> Tuple[pd.D
                 history_kwargs,
             )
 
-            if period:
+            if effective_period or _MIN_FALLBACK_HISTORY_DAYS:
                 fallback_end = (datetime.utcnow() - timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
-                fallback_start = fallback_end - _period_to_timedelta(period)
+                fallback_span = max(
+                    _period_to_timedelta(effective_period) if effective_period else timedelta(days=_MIN_FALLBACK_HISTORY_DAYS),
+                    timedelta(days=_MIN_FALLBACK_HISTORY_DAYS),
+                )
+                fallback_start = fallback_end - fallback_span
                 if fallback_start >= fallback_end:
                     fallback_start = fallback_end - timedelta(days=7)
                 fallback_kwargs = _build_history_kwargs(None)
@@ -143,6 +167,7 @@ async def fetch_history(ticker, period='1y', retries=2, backoff=1) -> Tuple[pd.D
                 fallback_context = {
                     "fallback_start": fallback_start.isoformat(),
                     "fallback_end": fallback_end.isoformat(),
+                    "fallback_span_days": fallback_span.days,
                 }
                 logger.debug(
                     "Retrying %s with explicit date range start=%s end=%s",
@@ -177,6 +202,9 @@ async def fetch_history(ticker, period='1y', retries=2, backoff=1) -> Tuple[pd.D
                 logger.info(log_message)
             else:
                 logger.warning(log_message)
+        finally:
+            if _REQUEST_THROTTLE_SECONDS and _REQUEST_THROTTLE_SECONDS > 0:
+                await asyncio.sleep(_REQUEST_THROTTLE_SECONDS)
 
         if attempt < retries:
             if last_error and _is_non_retriable_error(last_error):
@@ -197,7 +225,8 @@ async def fetch_history(ticker, period='1y', retries=2, backoff=1) -> Tuple[pd.D
         "symbol": fetch_ticker,
         "attempts": attempts,
         "non_retriable": bool(last_error and _is_non_retriable_error(last_error)),
-        "requested_period": period,
+        "requested_period": requested_period,
+        "effective_period": effective_period,
     }
     if fallback_context:
         failure_details.update(fallback_context)

--- a/rebound_scenarios.py
+++ b/rebound_scenarios.py
@@ -390,7 +390,8 @@ class ScenarioRunner:
                     return None
                 # Use a short period and fewer retries for a quick check.
                 # fetch_history is already async, so we can await it directly.
-                df, _ = await data_loader.fetch_history(ticker=ticker, period="1mo", retries=1)
+                validation_period = getattr(config, "VALIDATION_HISTORY_PERIOD", "6mo")
+                df, _ = await data_loader.fetch_history(ticker=ticker, period=validation_period, retries=1)
                 return ticker if df is not None and not df.empty else None
 
         semaphore = asyncio.Semaphore(20)  # Use higher concurrency for these quick checks

--- a/ticker_utils.py
+++ b/ticker_utils.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import re
 
 # Pre-compile a regex for share-class tickers that Yahoo expects with hyphen.
-_SHARE_CLASS_PATTERN = re.compile(r"^(?P<base>[A-Z0-9]+)\.(?P<class>[A-Z])$")
+# Require the base symbol to start with a letter so exchange suffixes like ``4188.T``
+# are not mis-identified as share classes.
+_SHARE_CLASS_PATTERN = re.compile(r"^(?P<base>[A-Z]+[A-Z0-9]*)\.(?P<class>[A-Z])$")
 
 
 def normalize_ticker_for_yfinance(ticker: str) -> str:


### PR DESCRIPTION
## Summary
- extend the default history request configuration so short periods are automatically stretched and fallbacks span at least six months
- add a configurable inter-request delay and expose more context when history downloads fail
- use the extended validation period during ticker checks and avoid rewriting exchange suffixes to hyphenated forms

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7a85d4b9c832f82ed0c4a50cf14fa