### PR TITLE
Improve LSE data fetching stability

### DIFF
--- a/data_loader.py
+++ b/data_loader.py
@@ -25,7 +25,11 @@ logger = logging.getLogger(__name__)
 FAILURE_CACHE_EXPIRY_HOURS = getattr(config, "FAILED_HISTORY_CACHE_EXPIRY_HOURS", 6)
 _MINIMUM_HISTORY_PERIOD = getattr(config, "MINIMUM_HISTORY_PERIOD", None)
 _MIN_FALLBACK_HISTORY_DAYS = getattr(config, "MIN_FALLBACK_HISTORY_DAYS", 180)
-_REQUEST_THROTTLE_SECONDS = getattr(config, "YFINANCE_THROTTLE_SECONDS", 0.0)
+_MINIMUM_THROTTLE_SECONDS = 1.0
+_REQUEST_THROTTLE_SECONDS = max(
+    getattr(config, "YFINANCE_THROTTLE_SECONDS", _MINIMUM_THROTTLE_SECONDS),
+    _MINIMUM_THROTTLE_SECONDS,
+)
 _last_failed_tickers: Dict[str, Dict[str, str]] = {}
 
 
@@ -69,7 +73,7 @@ def _build_history_kwargs(period: str | None) -> Dict[str, object]:
     """Centralise kwargs used for yfinance history downloads."""
     kwargs: Dict[str, object] = {
         "interval": "1d",
-        "auto_adjust": False,
+        "auto_adjust": True,
         "actions": False,
         "prepost": False,
     }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,11 @@
 PyQt6
-pandas
+yfinance>=0.2.43
+pandas>=2.2.2
 numpy
-yfinance
 lxml
 openpyxl
 matplotlib
 mplfinance
 aiohttp
 curl-cffi
+requests>=2.32.0


### PR DESCRIPTION
## Summary
- ensure yfinance history requests auto-adjust prices while respecting a minimum one-second throttle
- refresh dependency minimums for yfinance, pandas, and requests to pick up upstream fixes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7b0fdc344832fb2850d504f14fb6b