### PR TITLE
Fix share-class normalization for exchange suffixes

### DIFF
--- a/test_ticker_utils.py
+++ b/test_ticker_utils.py
@@ -1,0 +1,23 @@
+import pytest
+
+from ticker_utils import normalize_ticker_for_yfinance
+
+
+@pytest.mark.parametrize(
+    "original, expected",
+    [
+        ("BRK.B", "BRK-B"),
+        ("bf.a", "BF-A"),
+        ("HEI.C", "HEI-C"),
+    ],
+)
+def test_share_class_suffixes_are_hyphenated(original, expected):
+    assert normalize_ticker_for_yfinance(original) == expected
+
+
+def test_london_exchange_suffix_remains_unchanged():
+    assert normalize_ticker_for_yfinance("GLEN.L") == "GLEN.L"
+
+
+def test_tokyo_numeric_ticker_remains_unchanged():
+    assert normalize_ticker_for_yfinance("7203.T") == "7203.T"

--- a/ticker_utils.py
+++ b/ticker_utils.py
@@ -9,6 +9,12 @@ import re
 # are not mis-identified as share classes.
 _SHARE_CLASS_PATTERN = re.compile(r"^(?P<base>[A-Z]+[A-Z0-9]*)\.(?P<class>[A-Z])$")
 
+# Yahoo only expects a hyphen for a very small set of US share-class suffixes
+# (mainly ``.A``/``.B``/``.C``). Suffixes such as ``.L`` or ``.F`` indicate the
+# exchange rather than a share class, so we explicitly guard against rewriting
+# those tickers to avoid breaking lookups for markets like London or Frankfurt.
+_SHARE_CLASS_SUFFIXES = frozenset({"A", "B", "C"})
+
 
 def normalize_ticker_for_yfinance(ticker: str) -> str:
     """Return a Yahoo Finance compatible ticker symbol.
@@ -35,8 +41,9 @@ def normalize_ticker_for_yfinance(ticker: str) -> str:
     if not cleaned:
         return cleaned
 
-    match = _SHARE_CLASS_PATTERN.match(cleaned.upper())
-    if match:
+    upper_cleaned = cleaned.upper()
+    match = _SHARE_CLASS_PATTERN.match(upper_cleaned)
+    if match and match.group('class') in _SHARE_CLASS_SUFFIXES:
         return f"{match.group('base')}-{match.group('class')}"
 
     return cleaned


### PR DESCRIPTION
## Summary
- guard the ticker normalization helper so exchange suffixes like .L stay intact while valid share classes are still hyphenated
- add regression tests covering share-class hyphenation and common exchange suffixes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7d349ad7c832f9e80e15a4addb52b